### PR TITLE
Remove AWS PDK references from README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,63 @@ This repository contains example projects showing how you can use the various co
 
 ## Getting started
 
-This repo is managed by the AWS Project Development Kit (PDK), for help in getting started take a look at the [Developer Guide](https://aws.github.io/aws-pdk/developer_guides/infrastructure/index.html).
+This repository is organized as a monorepo containing multiple example projects demonstrating the use of Serverless DNA Constructs. Each example project is self-contained and can be built and deployed independently.
+
+For more information about AWS CDK, refer to the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
 
 ### Quick Start
 
-This project uses the AWS Project Development kit to manage a complete collection of example projects as a mono-repo.  AWS PDK uses [Projen](https://projen.io) to manage the mono-repo using a custom projen template which wraps up mono-repo management with typescript and [nx](https://nx.dev/).  Follow the getting started guide for the [aws-pdk](https://aws.github.io/aws-pdk/getting_started/index.html).
+This project is managed as a monorepo using [pnpm workspaces](https://pnpm.io/workspaces) and [nx](https://nx.dev/) for build orchestration. The monorepo structure allows for efficient management of multiple related example projects while maintaining clear separation between them.
 
-The example projects are all logically named following the folders the example code is stored in.  For example, the example project for SocketTasks Construct can be found in the **"examples/sockets/tasks"** folder, so its name will be "examples/sockets/tasks".  This naming convention is deliberate since the repo is a mono-repo and the name of the sub-projects enables you to run commands to build, deploy and destroy each of the projects in your own AWS account.
+The example projects are all logically named following the folders the example code is stored in.  For example, the example project for SocketTasks Construct can be found in the **"examples/sockets/tasks"** folder, so its name will be "examples/sockets/tasks".  This naming convention is deliberate so that when working with the repo you can easily identify which project you're targeting.
 
-To build the example projects (all of them):
+#### Building Projects
 
-```bash
-pdk build
-```
-
-To build the **examples/sockets/tasks** project:
+To build all example projects:
 
 ```bash
-pdk nx run examples/sockets/tasks:build
+pnpm build
 ```
 
-Deploying a project using "nx":
+To build a specific project (e.g., **examples/sockets/tasks**):
 
 ```bash
-pdk nx run examples/sockets/tasks:deploy --require-approval never
+npx nx run examples/sockets/tasks:build
 ```
 
-Deployment requires the `--require-approval never` flag since the actual `cdk deploy` is executed in a sub-process without an interactive shell.
-
-Destroying a deployed stack using "nx":
+Or navigate to the project directory and build directly:
 
 ```bash
-pdk nx run examples/sockets/tasks::destroy -f 
+cd examples/sockets/tasks
+npm run build
 ```
 
-The `-f` force flag is required, again because nx executes this in a sub-process without an interactive shell.
+#### Deploying Projects
+
+To deploy a project using nx:
+
+```bash
+npx nx run examples/sockets/tasks:deploy --require-approval never
+```
+
+Or navigate to the project directory and use standard AWS CDK commands:
+
+```bash
+cd examples/sockets/tasks
+npm run deploy
+```
+
+#### Destroying Deployed Stacks
+
+To destroy a deployed stack using nx:
+
+```bash
+npx nx run examples/sockets/tasks:destroy
+```
+
+Or using standard CDK commands from the project directory:
+
+```bash
+cd examples/sockets/tasks
+npm run destroy
+```

--- a/examples/sockets/api/README.md
+++ b/examples/sockets/api/README.md
@@ -1,3 +1,25 @@
 ## Getting started
 
-Refer to [Developer Guide](https://aws.github.io/aws-pdk/developer_guides/infrastructure/index.html)
+This example demonstrates the use of Serverless DNA Constructs for building socket-based APIs with AWS CDK.
+
+For more information about AWS CDK, refer to the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
+
+### Building and Deploying
+
+To build this project:
+
+```bash
+npm run build
+```
+
+To deploy this project:
+
+```bash
+npm run deploy
+```
+
+To destroy the deployed stack:
+
+```bash
+npm run destroy
+```

--- a/examples/sockets/tasks/README.md
+++ b/examples/sockets/tasks/README.md
@@ -1,41 +1,53 @@
-# Serverless DNA Constructs Examples
+# Socket Tasks Example
 
-This repository contains example projects showing how you can use the various constructs published in the Serverless DNA Constructs AWS CDK Library.  All the examples can be found in the **examples** folder of the repo.  Please feel free to explore and use the content provided in this repo to help accelerate your AWS CDK journey.
+This example demonstrates the use of the SocketTasks Construct from the Serverless DNA Constructs AWS CDK Library.
+
+For more information about the Serverless DNA Constructs, please visit the main repository at [github.com/serverless-dna/constructs](https://github.com/serverless-dna/constructs/).
 
 ## Getting started
 
-This repo is managed by the AWS Project Development Kit (PDK), for help in getting started take a look at the [Developer Guide](https://aws.github.io/aws-pdk/developer_guides/infrastructure/index.html).
+This project demonstrates how to use the SocketTasks construct to build serverless applications with AWS CDK.
 
-### Quick Start
+For more information about AWS CDK, refer to the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
 
-This project uses the AWS Project Development kit to manage a complete collection of example projects as a mono-repo.  AWS PDK uses [Projen](https://projen.io) to manage the mono-repo using a custom projen template which wraps up mono-repo management with typescript and [nx](https://nx.dev/).  Follow the getting started guide for the [aws-pdk](https://aws.github.io/aws-pdk/getting_started/index.html).
+### Building and Deploying
 
-The example projects are all logically named following the folders the example code is stored in.  For example, the example project for SocketTasks Construct can be found in the **"examples/sockets/tasks"** folder, so its name will be "examples/sockets/tasks".  This naming convention is deliberate since the repo is a mono-repo and the name of the sub-projects enables you to run commands to build, deploy and destroy each of the projects in your own AWS account.
-
-To build the example projects (all of them):
+To build this project:
 
 ```bash
-pdk build
+npm run build
 ```
 
-To build the **examples/sockets/tasks** project:
+To deploy this project:
 
 ```bash
-pdk nx run examples/sockets/tasks:build
+npm run deploy
 ```
 
-Deploying a project using "nx":
+To destroy the deployed stack:
 
 ```bash
-pdk nx run examples/sockets/tasks:deploy --require-approval never
+npm run destroy
 ```
 
-Deployment requires the `--require-approval never` flag since the actual `cdk deploy` is executed in a sub-process without an interactive shell.
+### Running from the Repository Root
 
-Destroying a deployed stack using "nx":
+If you prefer to use the monorepo tooling from the root directory, you can use nx:
+
+To build this specific project:
 
 ```bash
-pdk nx run examples/sockets/tasks::destroy -f 
+npx nx run examples/sockets/tasks:build
 ```
 
-The `-f` force flag is required, again because nx executes this in a sub-process without an interactive shell.
+To deploy this project:
+
+```bash
+npx nx run examples/sockets/tasks:deploy
+```
+
+To destroy the deployed stack:
+
+```bash
+npx nx run examples/sockets/tasks:destroy
+```

--- a/examples/vpc/private/README.md
+++ b/examples/vpc/private/README.md
@@ -1,7 +1,51 @@
 # Private VPC Construct
 
-This example project is an example use case for the `PrivateVPC` [Serverless DNA Construct](https://github.com/serverless-dna/constructs/).
+This example project demonstrates the use of the `PrivateVPC` construct from the [Serverless DNA Constructs library](https://github.com/serverless-dna/constructs/).
 
 ## Getting started
 
-This project is built using the `aws-pdk` library which is based upon [projen](https://projen.io).  Refer to [Developer Guide](https://aws.github.io/aws-pdk/developer_guides/infrastructure/index.html).
+This project demonstrates how to use the PrivateVPC construct to create isolated VPC environments with AWS CDK.
+
+For more information about AWS CDK, refer to the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html).
+
+### Building and Deploying
+
+To build this project:
+
+```bash
+npm run build
+```
+
+To deploy this project:
+
+```bash
+npm run deploy
+```
+
+To destroy the deployed stack:
+
+```bash
+npm run destroy
+```
+
+### Running from the Repository Root
+
+If you prefer to use the monorepo tooling from the root directory, you can use nx:
+
+To build this specific project:
+
+```bash
+npx nx run examples/vpc/private:build
+```
+
+To deploy this project:
+
+```bash
+npx nx run examples/vpc/private:deploy
+```
+
+To destroy the deployed stack:
+
+```bash
+npx nx run examples/vpc/private:destroy
+```


### PR DESCRIPTION
## Overview
This PR removes all references to the AWS Project Development Kit (PDK) from README files across the repository and replaces them with appropriate generic documentation that accurately reflects the current project structure.

## Changes Made

### Root README.md
- ✅ Removed paragraph about PDK management
- ✅ Removed section describing PDK mono-repo structure with Projen and NX
- ✅ Replaced with generic documentation describing the repository as a collection of AWS CDK construct examples

### examples/sockets/api/README.md
- ✅ Removed references to PDK Developer Guide URLs (https://aws.github.io/aws-pdk/developer_guides/infrastructure/index.html)
- ✅ Updated with standard AWS CDK documentation references

### examples/sockets/tasks/README.md
- ✅ Removed paragraph about PDK management
- ✅ Removed PDK-specific build and deployment commands (`pdk build`, `pdk nx run`)
- ✅ Replaced with standard npm/pnpm and CDK commands

### examples/vpc/private/README.md
- ✅ Removed references to aws-pdk library
- ✅ Removed PDK Developer Guide URLs
- ✅ Replaced with standard AWS CDK documentation references

## Requirements Implemented
All README files now accurately reflect the current project structure without any PDK dependency, making the documentation clearer and more maintainable for users who are working with standard AWS CDK constructs.

## Impact
- Documentation is now aligned with the actual project structure
- Users will no longer be confused by references to PDK tooling that is not in use
- Standard AWS CDK workflows and commands are now properly documented